### PR TITLE
refactor: resolve installation warning

### DIFF
--- a/install-openvpn3.sh
+++ b/install-openvpn3.sh
@@ -2,9 +2,11 @@
 
 set -euo pipefail
 
-curl -fsSL https://swupdate.openvpn.net/repos/openvpn-repo-pkg-key.pub | gpg --dearmor > /tmp/openvpn-repo-pkg-keyring.gpg
+curl -fsSL https://swupdate.openvpn.net/repos/openvpn-repo-pkg-key.pub \
+    | gpg --dearmor > /tmp/openvpn-repo-pkg-keyring.gpg
 sudo mv /tmp/openvpn-repo-pkg-keyring.gpg /etc/apt/trusted.gpg.d/.
-echo "deb [arch=amd64] https://swupdate.openvpn.net/community/openvpn3/repos jammy main" > /tmp/openvpn3.list
+echo "deb [arch=amd64] https://swupdate.openvpn.net/community/openvpn3/repos jammy main" \
+    > /tmp/openvpn3.list
 sudo mv /tmp/openvpn3.list /etc/apt/sources.list.d/openvpn3.list
 sudo apt-get update
 sudo apt-get install -y openvpn3

--- a/install-openvpn3.sh
+++ b/install-openvpn3.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 curl -fsSL https://swupdate.openvpn.net/repos/openvpn-repo-pkg-key.pub | gpg --dearmor > /tmp/openvpn-repo-pkg-keyring.gpg
 sudo mv /tmp/openvpn-repo-pkg-keyring.gpg /etc/apt/trusted.gpg.d/.
-curl -fsSL https://swupdate.openvpn.net/community/openvpn3/repos/openvpn3-jammy.list > /tmp/openvpn3.list
+echo "deb [arch=amd64] https://swupdate.openvpn.net/community/openvpn3/repos jammy main" > /tmp/openvpn3.list
 sudo mv /tmp/openvpn3.list /etc/apt/sources.list.d/openvpn3.list
 sudo apt-get update
 sudo apt-get install -y openvpn3


### PR DESCRIPTION
The warning was:
```
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://swupdate.openvpn.net/community/openvpn3/repos jammy InRelease' doesn't support architecture 'i386'
```
